### PR TITLE
fixed spelling mistake which made search not function

### DIFF
--- a/app/core/job_searchers.php
+++ b/app/core/job_searchers.php
@@ -23,7 +23,7 @@ class JobSearcher
         }
         
         if (!empty($query)) {
-            $conditions[] = "job_searchers.name LIKE ?";
+            $conditions[] = "job_searchers.title LIKE ?";
             $params[] = "%$query%";
         }
 


### PR DESCRIPTION
* [`app/core/job_searchers.php`](diffhunk://#diff-73794f1d6a26e685572267319fc3dc9b6960b9812bf78e6d4276fec9987e9041L26-R26): Changed the search condition from `job_searchers.name` to `job_searchers.title` to ensure the search query matches job titles instead of names.